### PR TITLE
Prevent unexpected exit status 1 when deleting `codecoverage` metadata

### DIFF
--- a/lib/fastlane/plugin/codecov_reporter/actions/codecov_reporter_action.rb
+++ b/lib/fastlane/plugin/codecov_reporter/actions/codecov_reporter_action.rb
@@ -17,8 +17,8 @@ module Fastlane
 
         UI.message "Removing the bash script I got from Codecov.io"
         sh "rm #{ENV['PWD']}/codecov_reporter.sh"
-        UI.message "Removing the created coverage.txt files"
-        sh "rm *.coverage.txt"
+        UI.message "Removing the created coverage.txt files, if any."
+        sh "rm -f *.coverage.txt"
         UI.message "All was well"
       end
 

--- a/spec/codecov_reporter_action_spec.rb
+++ b/spec/codecov_reporter_action_spec.rb
@@ -4,7 +4,7 @@ describe Fastlane::Actions::CodecovReporterAction do
       expect(Fastlane::UI).to receive(:message).with("I am Getting the latest bash script from Codecov.io")
       expect(Fastlane::UI).to receive(:message).with("It looks like I'm working with a public repository")
       expect(Fastlane::UI).to receive(:message).with("Removing the bash script I got from Codecov.io")
-      expect(Fastlane::UI).to receive(:message).with("Removing the created coverage.txt files")
+      expect(Fastlane::UI).to receive(:message).with("Removing the created coverage.txt files, if any.")
       expect(Fastlane::UI).to receive(:message).with("All was well")
 
       Fastlane::Actions::CodecovReporterAction.run({})


### PR DESCRIPTION
## What

As very last step, this action implementation gently cleans everything after itself. Although, last script from `codecoverage.io` takes now care of this for us.
The result of deleting something that is not there, because already cleaned, causes the return of exit status 1

## How

I have added the `-f` option to rm such that we can prevent a change in the exit status if the remove can not find any matching file to delete.